### PR TITLE
extract string literals to dedicated component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.0 (2023-09-22)
+
+**Note:** Version bump only for package root
+
+
+
+
+
 ## 1.15.1-pr-84.0 (2023-09-14)
 
 **Note:** Version bump only for package root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.1 (2023-09-22)
+
+**Note:** Version bump only for package root
+
+
+
+
+
 ## 1.15.1-pr-91.0 (2023-09-22)
 
 **Note:** Version bump only for package root

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.1-pr-91.0",
+  "version": "1.15.1-pr-91.1",
   "command": {
     "version": {
       "message": "chore(release): %s",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.1-pr-84.0",
+  "version": "1.15.1-pr-91.0",
   "command": {
     "version": {
       "message": "chore(release): %s",

--- a/packages/design-system-angular/CHANGELOG.md
+++ b/packages/design-system-angular/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.0 (2023-09-22)
+
+**Note:** Version bump only for package @geovistory/design-system-angular
+
+
+
+
+
 ## 1.15.1-pr-84.0 (2023-09-14)
 
 **Note:** Version bump only for package @geovistory/design-system-angular

--- a/packages/design-system-angular/CHANGELOG.md
+++ b/packages/design-system-angular/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.1 (2023-09-22)
+
+**Note:** Version bump only for package @geovistory/design-system-angular
+
+
+
+
+
 ## 1.15.1-pr-91.0 (2023-09-22)
 
 **Note:** Version bump only for package @geovistory/design-system-angular

--- a/packages/design-system-angular/package-lock.json
+++ b/packages/design-system-angular/package-lock.json
@@ -40,7 +40,7 @@
     },
     "../design-system-web": {
       "name": "@geovistory/design-system-web",
-      "version": "1.15.1-pr-84.0",
+      "version": "1.15.1-pr-91.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-angular/package-lock.json
+++ b/packages/design-system-angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geovistory/design-system-angular",
-  "version": "1.15.1-pr-91.0",
+  "version": "1.15.1-pr-91.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-angular",
-      "version": "1.15.1-pr-91.0",
+      "version": "1.15.1-pr-91.1",
       "dependencies": {
         "@angular/animations": "~13.3.0",
         "@angular/common": "~13.3.0",
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "~13.3.0",
         "@angular/platform-browser-dynamic": "~13.3.0",
         "@angular/router": "~13.3.0",
-        "@geovistory/design-system-web": "1.15.1-pr-91.0",
+        "@geovistory/design-system-web": "1.15.1-pr-91.1",
         "@rollup/plugin-typescript": "^11.1.2",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",

--- a/packages/design-system-angular/package-lock.json
+++ b/packages/design-system-angular/package-lock.json
@@ -40,7 +40,7 @@
     },
     "../design-system-web": {
       "name": "@geovistory/design-system-web",
-      "version": "1.15.1-pr-91.0",
+      "version": "1.15.1-pr-91.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-angular/package-lock.json
+++ b/packages/design-system-angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geovistory/design-system-angular",
-  "version": "1.15.1-pr-84.0",
+  "version": "1.15.1-pr-91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-angular",
-      "version": "1.15.1-pr-84.0",
+      "version": "1.15.1-pr-91.0",
       "dependencies": {
         "@angular/animations": "~13.3.0",
         "@angular/common": "~13.3.0",
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "~13.3.0",
         "@angular/platform-browser-dynamic": "~13.3.0",
         "@angular/router": "~13.3.0",
-        "@geovistory/design-system-web": "1.15.1-pr-84.0",
+        "@geovistory/design-system-web": "1.15.1-pr-91.0",
         "@rollup/plugin-typescript": "^11.1.2",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",

--- a/packages/design-system-angular/package.json
+++ b/packages/design-system-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovistory/design-system-angular",
-  "version": "1.15.1-pr-84.0",
+  "version": "1.15.1-pr-91.0",
   "description": "geovistory.org's design system: web components",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "@angular/platform-browser": "~13.3.0",
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
-    "@geovistory/design-system-web": "1.15.1-pr-84.0",
+    "@geovistory/design-system-web": "1.15.1-pr-91.0",
     "@rollup/plugin-typescript": "^11.1.2",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/packages/design-system-angular/package.json
+++ b/packages/design-system-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovistory/design-system-angular",
-  "version": "1.15.1-pr-91.0",
+  "version": "1.15.1-pr-91.1",
   "description": "geovistory.org's design system: web components",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "@angular/platform-browser": "~13.3.0",
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
-    "@geovistory/design-system-web": "1.15.1-pr-91.0",
+    "@geovistory/design-system-web": "1.15.1-pr-91.1",
     "@rollup/plugin-typescript": "^11.1.2",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.0 (2023-09-22)
+
+**Note:** Version bump only for package @geovistory/design-system-react
+
+
+
+
+
 ## 1.15.1-pr-84.0 (2023-09-14)
 
 **Note:** Version bump only for package @geovistory/design-system-react

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.1 (2023-09-22)
+
+**Note:** Version bump only for package @geovistory/design-system-react
+
+
+
+
+
 ## 1.15.1-pr-91.0 (2023-09-22)
 
 **Note:** Version bump only for package @geovistory/design-system-react

--- a/packages/design-system-react/package-lock.json
+++ b/packages/design-system-react/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@geovistory/design-system-react",
-  "version": "1.15.1-pr-91.0",
+  "version": "1.15.1-pr-91.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-react",
-      "version": "1.15.1-pr-91.0",
+      "version": "1.15.1-pr-91.1",
       "dependencies": {
-        "@geovistory/design-system-web": "1.15.1-pr-91.0",
+        "@geovistory/design-system-web": "1.15.1-pr-91.1",
         "@ionic/core": "6.0.14",
         "@rollup/plugin-typescript": "^11.1.2"
       },

--- a/packages/design-system-react/package-lock.json
+++ b/packages/design-system-react/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../design-system-web": {
       "name": "@geovistory/design-system-web",
-      "version": "1.15.1-pr-84.0",
+      "version": "1.15.1-pr-91.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-react/package-lock.json
+++ b/packages/design-system-react/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../design-system-web": {
       "name": "@geovistory/design-system-web",
-      "version": "1.15.1-pr-91.0",
+      "version": "1.15.1-pr-91.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-react/package-lock.json
+++ b/packages/design-system-react/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@geovistory/design-system-react",
-  "version": "1.15.1-pr-84.0",
+  "version": "1.15.1-pr-91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-react",
-      "version": "1.15.1-pr-84.0",
+      "version": "1.15.1-pr-91.0",
       "dependencies": {
-        "@geovistory/design-system-web": "1.15.1-pr-84.0",
+        "@geovistory/design-system-web": "1.15.1-pr-91.0",
         "@ionic/core": "6.0.14",
         "@rollup/plugin-typescript": "^11.1.2"
       },

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@geovistory/design-system-react",
   "sideEffects": false,
-  "version": "1.15.1-pr-91.0",
+  "version": "1.15.1-pr-91.1",
   "description": "geovistory.org's design system: React components",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@geovistory/design-system-web": "1.15.1-pr-91.0",
+    "@geovistory/design-system-web": "1.15.1-pr-91.1",
     "@ionic/core": "6.0.14",
     "@rollup/plugin-typescript": "^11.1.2"
   },

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@geovistory/design-system-react",
   "sideEffects": false,
-  "version": "1.15.1-pr-84.0",
+  "version": "1.15.1-pr-91.0",
   "description": "geovistory.org's design system: React components",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@geovistory/design-system-web": "1.15.1-pr-84.0",
+    "@geovistory/design-system-web": "1.15.1-pr-91.0",
     "@ionic/core": "6.0.14",
     "@rollup/plugin-typescript": "^11.1.2"
   },

--- a/packages/design-system-web/CHANGELOG.md
+++ b/packages/design-system-web/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.1 (2023-09-22)
+
+**Note:** Version bump only for package @geovistory/design-system-web
+
+
+
+
+
 ## 1.15.1-pr-91.0 (2023-09-22)
 
 **Note:** Version bump only for package @geovistory/design-system-web

--- a/packages/design-system-web/CHANGELOG.md
+++ b/packages/design-system-web/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.15.1-pr-91.0 (2023-09-22)
+
+**Note:** Version bump only for package @geovistory/design-system-web
+
+
+
+
+
 ## 1.15.1-pr-84.0 (2023-09-14)
 
 **Note:** Version bump only for package @geovistory/design-system-web

--- a/packages/design-system-web/package-lock.json
+++ b/packages/design-system-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geovistory/design-system-web",
-  "version": "1.15.1-pr-91.0",
+  "version": "1.15.1-pr-91.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-web",
-      "version": "1.15.1-pr-91.0",
+      "version": "1.15.1-pr-91.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-web/package-lock.json
+++ b/packages/design-system-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geovistory/design-system-web",
-  "version": "1.15.1-pr-84.0",
+  "version": "1.15.1-pr-91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-web",
-      "version": "1.15.1-pr-84.0",
+      "version": "1.15.1-pr-91.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-web/package.json
+++ b/packages/design-system-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovistory/design-system-web",
-  "version": "1.15.1-pr-84.0",
+  "version": "1.15.1-pr-91.0",
   "description": "geovistory.org's design system: web components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/design-system-web/package.json
+++ b/packages/design-system-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovistory/design-system-web",
-  "version": "1.15.1-pr-91.0",
+  "version": "1.15.1-pr-91.1",
   "description": "geovistory.org's design system: web components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/design-system-web/src/components/geov-display-geosparql-wktliteral/geov-display-geosparql-wktliteral.tsx
+++ b/packages/design-system-web/src/components/geov-display-geosparql-wktliteral/geov-display-geosparql-wktliteral.tsx
@@ -1,4 +1,5 @@
-import { Component, Host, h, Prop } from '@stencil/core';
+import { Color } from '@ionic/core';
+import { Component, Fragment, Prop, h } from '@stencil/core';
 
 /**
  * This Component displays the coordinates given by a WKT literal string of this form:
@@ -14,6 +15,10 @@ export class GeovDisplayGeosparqlWktliteral {
    * the opengis value
    */
   @Prop() value: string;
+  /**
+   * Color assigned to ion-item
+   */
+  @Prop() color: Color = '';
 
   render() {
     //http://www.opengis.net/def/crs/EPSG/0/4326>POINT(4.79583 52.55417)
@@ -22,12 +27,15 @@ export class GeovDisplayGeosparqlWktliteral {
     const coordonnees = coord.split(' ');
 
     return (
-      <Host>
-        long: {coordonnees[0]}
-        <br />
-        lat: {coordonnees[1]}
-        <slot></slot>
-      </Host>
+      <Fragment>
+        <ion-item color={this.color} lines="none">
+          <ion-label>
+            long: {coordonnees[0]}
+            <br />
+            lat: {coordonnees[1]}
+          </ion-label>
+        </ion-item>
+      </Fragment>
     );
   }
 }

--- a/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.css
+++ b/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.css
@@ -1,0 +1,23 @@
+:host {
+  display: block;
+}
+
+.literal-container {
+  overflow: clip;
+  width: 100%;
+}
+
+.literal-container ion-button {
+  display: none;
+  margin-left: auto;
+}
+
+.label-container {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.label {
+  width: 100%;
+}

--- a/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.stories.tsx
+++ b/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.stories.tsx
@@ -1,0 +1,23 @@
+import { h } from '@stencil/core';
+import { stencilWrapper } from '../../../.storybook/lib/stencilWrapper';
+import { docsTemlpate } from '../../../.storybook/templates/docsTemplate';
+import componentApi from './docs-component-api.md?raw';
+import overview from './docs-overview.md?raw';
+export default {
+  title: 'Data Components/Entity/Display String Literal',
+  tags: ['autodocs'],
+  parameters: {
+    viewMode: 'docs',
+    docs: {
+      page: () => docsTemlpate(overview, componentApi),
+    },
+  },
+};
+
+export const XsdString = await stencilWrapper(
+  <geov-display-string-literal modalTitle="My predicate" label="This is a long long long long long label"></geov-display-string-literal>,
+);
+
+export const LangString = await stencilWrapper(
+  <geov-display-string-literal modalTitle="My predicate" label="This is a long long long long long label" language="fr"></geov-display-string-literal>,
+);

--- a/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.tsx
+++ b/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.tsx
@@ -1,0 +1,95 @@
+import { Color } from '@ionic/core';
+import { Component, Fragment, Prop, h } from '@stencil/core';
+import { eye } from 'ionicons/icons';
+
+/**
+ * This component displays string literals (with and without language)
+ *
+ * If the displayed string is overflows, the component shows a button
+ * to open a modal, where the full string is displayed.
+ *
+ * Resize the window to see the effect, in case the button is not displayed.
+ */
+@Component({
+  tag: 'geov-display-string-literal',
+  styleUrl: 'geov-display-string-literal.css',
+  shadow: true,
+})
+export class GeovDisplayStringLiteralLiteral {
+  /**
+   * Color assigned to ion-item
+   */
+  @Prop() color: Color = '';
+  /**
+   * Title of the modal, that opens when user clicks on show button
+   */
+  @Prop() modalTitle: string;
+  /**
+   * The label (string) to display
+   */
+  @Prop() label: string;
+  /**
+   * The language to display on the second line. Will be prefixed with @.
+   */
+  @Prop() language: string;
+  modal: HTMLIonModalElement;
+  labelContainer: Element;
+  literalContainer: HTMLIonItemElement;
+  itemButton: HTMLIonButtonElement;
+  componentDidLoad() {
+    this.resizePage();
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  resizePage() {
+    // Display Expand button if need. The page must be loaded in order to have the measurements
+    if (this.literalContainer && this.itemButton) {
+      if (this.labelContainer) {
+        // If size of text > size of container
+        if (this.labelContainer.scrollWidth > this.labelContainer.clientWidth) {
+          this.itemButton.style.display = 'block';
+        } else {
+          this.itemButton.style.display = 'none';
+        }
+      }
+    }
+  }
+
+  handleResize = () => {
+    this.resizePage();
+  };
+
+  open() {
+    this.modal.present();
+  }
+  dismiss() {
+    this.modal.dismiss();
+  }
+  render() {
+    return (
+      <Fragment>
+        <ion-item color={this.color} ref={el => (this.literalContainer = el as HTMLIonItemElement)} lines="none">
+          <ion-label class="literal-container">
+            <h2 ref={element => (this.labelContainer = element)}>{this.label}</h2>
+            {this.language && <p>@{this.language}</p>}
+          </ion-label>
+          <ion-button onClick={() => this.open()} ref={el => (this.itemButton = el as HTMLIonButtonElement)}>
+            <ion-icon icon={eye}></ion-icon>
+          </ion-button>
+        </ion-item>
+
+        <ion-modal ref={element => (this.modal = element)} onWillDismiss={() => this.dismiss()} isOpen={false}>
+          <ion-header>
+            <ion-toolbar>
+              <ion-buttons slot="end">
+                <ion-button onClick={() => this.dismiss()}>Close</ion-button>
+              </ion-buttons>
+              <ion-title>{this.modalTitle}</ion-title>
+            </ion-toolbar>
+          </ion-header>
+          <ion-content class="ion-padding">{this.label}</ion-content>
+        </ion-modal>
+      </Fragment>
+    );
+  }
+}

--- a/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.tsx
+++ b/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.tsx
@@ -34,7 +34,6 @@ export class GeovDisplayStringLiteralLiteral {
   @Prop() language: string;
   modal: HTMLIonModalElement;
   labelContainer: Element;
-  literalContainer: HTMLIonItemElement;
   itemButton: HTMLIonButtonElement;
   componentDidLoad() {
     this.resizePage();
@@ -43,14 +42,12 @@ export class GeovDisplayStringLiteralLiteral {
 
   resizePage() {
     // Display Expand button if need. The page must be loaded in order to have the measurements
-    if (this.literalContainer && this.itemButton) {
-      if (this.labelContainer) {
-        // If size of text > size of container
-        if (this.labelContainer.scrollWidth > this.labelContainer.clientWidth) {
-          this.itemButton.style.display = 'block';
-        } else {
-          this.itemButton.style.display = 'none';
-        }
+    if (this.labelContainer && this.itemButton) {
+      // If size of text > size of container
+      if (this.labelContainer.scrollWidth > this.labelContainer.clientWidth) {
+        this.itemButton.style.display = 'block';
+      } else {
+        this.itemButton.style.display = 'none';
       }
     }
   }
@@ -68,7 +65,7 @@ export class GeovDisplayStringLiteralLiteral {
   render() {
     return (
       <Fragment>
-        <ion-item color={this.color} ref={el => (this.literalContainer = el as HTMLIonItemElement)} lines="none">
+        <ion-item color={this.color} lines="none">
           <ion-label class="literal-container">
             <h2 ref={element => (this.labelContainer = element)}>{this.label}</h2>
             {this.language && <p>@{this.language}</p>}

--- a/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.css
+++ b/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.css
@@ -12,13 +12,3 @@ ion-card {
 geov-paginator {
   margin-left: auto;
 }
-
-.literal-container {
-  overflow: clip;
-  width: 100%;
-}
-
-.literal-container ion-button {
-  display: none;
-  margin-left: auto;
-}

--- a/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.stories.tsx
+++ b/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.stories.tsx
@@ -15,7 +15,7 @@ export default {
   },
 };
 
-export const EntityPropsWithPerson = await stencilWrapper(
+export const Person = await stencilWrapper(
   <geov-entity-props-by-predicate
     sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
     entityId="i151089"
@@ -27,7 +27,7 @@ export const EntityPropsWithPerson = await stencilWrapper(
   ></geov-entity-props-by-predicate>,
 );
 
-export const EntityPropsWithUriRegex = await stencilWrapper(
+export const UriRegex = await stencilWrapper(
   <geov-entity-props-by-predicate
     sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
     entityId="i151089"
@@ -41,7 +41,7 @@ export const EntityPropsWithUriRegex = await stencilWrapper(
   ></geov-entity-props-by-predicate>,
 );
 
-export const EntityPropsWithPaginatedShipVoyages = await stencilWrapper(
+export const PaginatedShipVoyages = await stencilWrapper(
   <geov-entity-props-by-predicate
     sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
     entityId="i209502"
@@ -53,7 +53,7 @@ export const EntityPropsWithPaginatedShipVoyages = await stencilWrapper(
   ></geov-entity-props-by-predicate>,
 );
 
-export const EntityPropsWithDateTimeDescription = await stencilWrapper(
+export const DateTimeDescription = await stencilWrapper(
   <geov-entity-props-by-predicate
     sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
     entityId="i151089ts"
@@ -65,7 +65,7 @@ export const EntityPropsWithDateTimeDescription = await stencilWrapper(
   ></geov-entity-props-by-predicate>,
 );
 
-export const EntityPropsWithXsdString = await stencilWrapper(
+export const XsdString = await stencilWrapper(
   <geov-entity-props-by-predicate
     sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
     entityId="i215634"
@@ -77,7 +77,20 @@ export const EntityPropsWithXsdString = await stencilWrapper(
   ></geov-entity-props-by-predicate>,
 );
 
-export const EntityPropsWithLangString = await stencilWrapper(
+export const XsdStringPreloaded = await stencilWrapper(
+  <geov-entity-props-by-predicate
+    sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
+    entityId="i215635"
+    totalCount={1}
+    language="en"
+    predicateUri="https://ontome.net/ontology/p1113"
+    predicateLabel="refers to name"
+    fetchBeforeRender={true}
+    _ssrId="data-entity-props-by-predicate-1"
+  ></geov-entity-props-by-predicate>,
+);
+
+export const LangString = await stencilWrapper(
   <geov-entity-props-by-predicate
     sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
     entityId="i2345931"
@@ -89,16 +102,15 @@ export const EntityPropsWithLangString = await stencilWrapper(
   ></geov-entity-props-by-predicate>,
 );
 
-export const EntityPropsWithXsdStringPreloaded = await stencilWrapper(
+export const WktLiteral = await stencilWrapper(
   <geov-entity-props-by-predicate
-    sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
-    entityId="i215635"
+    sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT}
+    entityId="i253708"
     totalCount={1}
     language="en"
-    predicateUri="https://ontome.net/ontology/p1113"
-    predicateLabel="refers to name"
+    predicateUri="https://ontome.net/ontology/p148"
+    predicateLabel="WAS WITHIN"
     fetchBeforeRender={true}
-    _ssrId="data-entity-props-by-predicate-1"
   ></geov-entity-props-by-predicate>,
 );
 

--- a/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.tsx
+++ b/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.tsx
@@ -243,13 +243,20 @@ export class GeovEntityPropsByPredicate {
       );
     }
 
-    switch (item.dt.value) {
+    switch (item.dt?.value) {
       case 'http://www.opengis.net/ont/geosparql#wktLiteral':
-        return <geov-display-geosparql-wktliteral value={item.entity?.value}></geov-display-geosparql-wktliteral>;
+        return <geov-display-geosparql-wktliteral color={this.color} value={item.entity?.value}></geov-display-geosparql-wktliteral>;
       case 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString':
       case 'http://www.w3.org/2001/XMLSchema#string':
       default:
-        return <geov-display-string-literal modalTitle={this.predicateLabel} label={item.entity?.value} language={item.entity?.['xml:lang']}></geov-display-string-literal>;
+        return (
+          <geov-display-string-literal
+            color={this.color}
+            modalTitle={this.predicateLabel}
+            label={item.entity?.value}
+            language={item.entity?.['xml:lang']}
+          ></geov-display-string-literal>
+        );
     }
   }
 


### PR DESCRIPTION
In the reiview of PR 84 I observed that the button to open a modal for long string literals does not work in all situations. 

This PR adds a working solution:
- extract string literals to dedicated component `geov-display-string-literals` in order to isolate the problem and have smaller components
- fix the problem by using the correct parent element to test `.scrollWidth`