### PR TITLE
52-proposal-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.16.1-pr-101.0 (2023-10-26)
+
+**Note:** Version bump only for package root
+
+
+
+
+
 ## 1.16.1-pr-98.0 (2023-10-25)
 
 **Note:** Version bump only for package root

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.16.1-pr-98.0",
+  "version": "1.16.1-pr-101.0",
   "command": {
     "version": {
       "message": "chore(release): %s",

--- a/packages/design-system-angular/CHANGELOG.md
+++ b/packages/design-system-angular/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.16.1-pr-101.0 (2023-10-26)
+
+**Note:** Version bump only for package @geovistory/design-system-angular
+
+
+
+
+
 ## 1.16.1-pr-98.0 (2023-10-25)
 
 **Note:** Version bump only for package @geovistory/design-system-angular

--- a/packages/design-system-angular/package-lock.json
+++ b/packages/design-system-angular/package-lock.json
@@ -40,7 +40,7 @@
     },
     "../design-system-web": {
       "name": "@geovistory/design-system-web",
-      "version": "1.16.1-pr-98.0",
+      "version": "1.16.1-pr-101.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-angular/package-lock.json
+++ b/packages/design-system-angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geovistory/design-system-angular",
-  "version": "1.16.1-pr-98.0",
+  "version": "1.16.1-pr-101.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-angular",
-      "version": "1.16.1-pr-98.0",
+      "version": "1.16.1-pr-101.0",
       "dependencies": {
         "@angular/animations": "~13.3.0",
         "@angular/common": "~13.3.0",
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "~13.3.0",
         "@angular/platform-browser-dynamic": "~13.3.0",
         "@angular/router": "~13.3.0",
-        "@geovistory/design-system-web": "1.16.1-pr-98.0",
+        "@geovistory/design-system-web": "1.16.1-pr-101.0",
         "@rollup/plugin-typescript": "^11.1.2",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",

--- a/packages/design-system-angular/package.json
+++ b/packages/design-system-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovistory/design-system-angular",
-  "version": "1.16.1-pr-98.0",
+  "version": "1.16.1-pr-101.0",
   "description": "geovistory.org's design system: web components",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "@angular/platform-browser": "~13.3.0",
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
-    "@geovistory/design-system-web": "1.16.1-pr-98.0",
+    "@geovistory/design-system-web": "1.16.1-pr-101.0",
     "@rollup/plugin-typescript": "^11.1.2",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/packages/design-system-react/CHANGELOG.md
+++ b/packages/design-system-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.16.1-pr-101.0 (2023-10-26)
+
+**Note:** Version bump only for package @geovistory/design-system-react
+
+
+
+
+
 ## 1.16.1-pr-98.0 (2023-10-25)
 
 **Note:** Version bump only for package @geovistory/design-system-react

--- a/packages/design-system-react/package-lock.json
+++ b/packages/design-system-react/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../design-system-web": {
       "name": "@geovistory/design-system-web",
-      "version": "1.16.1-pr-98.0",
+      "version": "1.16.1-pr-101.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-react/package-lock.json
+++ b/packages/design-system-react/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@geovistory/design-system-react",
-  "version": "1.16.1-pr-98.0",
+  "version": "1.16.1-pr-101.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-react",
-      "version": "1.16.1-pr-98.0",
+      "version": "1.16.1-pr-101.0",
       "dependencies": {
-        "@geovistory/design-system-web": "1.16.1-pr-98.0",
+        "@geovistory/design-system-web": "1.16.1-pr-101.0",
         "@ionic/core": "6.0.14",
         "@rollup/plugin-typescript": "^11.1.2"
       },

--- a/packages/design-system-react/package.json
+++ b/packages/design-system-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@geovistory/design-system-react",
   "sideEffects": false,
-  "version": "1.16.1-pr-98.0",
+  "version": "1.16.1-pr-101.0",
   "description": "geovistory.org's design system: React components",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "@geovistory/design-system-web": "1.16.1-pr-98.0",
+    "@geovistory/design-system-web": "1.16.1-pr-101.0",
     "@ionic/core": "6.0.14",
     "@rollup/plugin-typescript": "^11.1.2"
   },

--- a/packages/design-system-web/CHANGELOG.md
+++ b/packages/design-system-web/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.16.1-pr-101.0 (2023-10-26)
+
+**Note:** Version bump only for package @geovistory/design-system-web
+
+
+
+
+
 ## 1.16.1-pr-98.0 (2023-10-25)
 
 **Note:** Version bump only for package @geovistory/design-system-web

--- a/packages/design-system-web/package-lock.json
+++ b/packages/design-system-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geovistory/design-system-web",
-  "version": "1.16.1-pr-98.0",
+  "version": "1.16.1-pr-101.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geovistory/design-system-web",
-      "version": "1.16.1-pr-98.0",
+      "version": "1.16.1-pr-101.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/design-system-web/package.json
+++ b/packages/design-system-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geovistory/design-system-web",
-  "version": "1.16.1-pr-98.0",
+  "version": "1.16.1-pr-101.0",
   "description": "geovistory.org's design system: web components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/design-system-web/src/components/geov-display-geosparql-wktliteral/geov-display-geosparql-wktliteral.tsx
+++ b/packages/design-system-web/src/components/geov-display-geosparql-wktliteral/geov-display-geosparql-wktliteral.tsx
@@ -1,4 +1,3 @@
-import { Color } from '@ionic/core';
 import { Component, Fragment, Prop, h } from '@stencil/core';
 
 /**
@@ -15,26 +14,16 @@ export class GeovDisplayGeosparqlWktliteral {
    * the opengis value
    */
   @Prop() value: string;
-  /**
-   * Color assigned to ion-item
-   */
-  @Prop() color: Color = '';
 
   render() {
     //http://www.opengis.net/def/crs/EPSG/0/4326>POINT(4.79583 52.55417)
-    let coord = this.value.replace('http://www.opengis.net/def/crs/EPSG/0/4326>POINT(', '');
+    let coord = this.value.replace('<http://www.opengis.net/def/crs/EPSG/0/4326>POINT(', '');
     coord = coord.replace(')', '');
     const coordonnees = coord.split(' ');
 
     return (
       <Fragment>
-        <ion-item color={this.color} lines="none">
-          <ion-label>
-            long: {coordonnees[0]}
-            <br />
-            lat: {coordonnees[1]}
-          </ion-label>
-        </ion-item>
+        long: {coordonnees[0]}, lat: {coordonnees[1]}
       </Fragment>
     );
   }

--- a/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.css
+++ b/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.css
@@ -2,6 +2,10 @@
   display: block;
 }
 
+.wrapper {
+  display: flex;
+}
+
 .literal-container {
   overflow: clip;
   width: 100%;
@@ -18,10 +22,29 @@
   text-overflow: ellipsis;
 }
 
+.color-light {
+  color: var(--ion-color-step-600, black);
+}
+
 .label {
   width: 100%;
 }
 
-ion-item {
-  border-top: solid 1px #eee;
+.open-modal-btn {
+  min-height: 0;
+  padding: 0;
+  margin: 0 0 0 0.25rem;
+  --padding-inline-start: 0;
+  --padding-inline-end: 0;
+  --padding-top: 0;
+  --padding-bottom: 0;
+  --padding-start: 0;
+  --padding-end: 0;
 }
+
+/* ion-item {
+  border-top: var(--border-top, solid 1px #eee);
+  --padding-start: var(--padding-start);
+  --inner-padding-top: 0;
+  --min-height: var(--min-height);
+} */

--- a/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.tsx
+++ b/packages/design-system-web/src/components/geov-display-string-literal/geov-display-string-literal.tsx
@@ -1,4 +1,3 @@
-import { Color } from '@ionic/core';
 import { Component, Fragment, Prop, h } from '@stencil/core';
 import { eye } from 'ionicons/icons';
 
@@ -17,10 +16,6 @@ import { eye } from 'ionicons/icons';
 })
 export class GeovDisplayStringLiteralLiteral {
   /**
-   * Color assigned to ion-item
-   */
-  @Prop() color: Color = '';
-  /**
    * Title of the modal, that opens when user clicks on show button
    */
   @Prop() modalTitle: string;
@@ -32,6 +27,7 @@ export class GeovDisplayStringLiteralLiteral {
    * The language to display on the second line. Will be prefixed with @.
    */
   @Prop() language: string;
+
   modal: HTMLIonModalElement;
   labelContainer: Element;
   itemButton: HTMLIonButtonElement;
@@ -65,15 +61,16 @@ export class GeovDisplayStringLiteralLiteral {
   render() {
     return (
       <Fragment>
-        <ion-item color={this.color} lines="none">
-          <ion-label class="literal-container">
-            <h2 ref={element => (this.labelContainer = element)}>{this.label}</h2>
-            {this.language && <p>@{this.language}</p>}
-          </ion-label>
-          <ion-button onClick={() => this.open()} ref={el => (this.itemButton = el as HTMLIonButtonElement)}>
+        <div class="wrapper">
+          <div class="literal-container">
+            <div ref={element => (this.labelContainer = element)}>
+              {this.label} {this.language && <span class="color-light">@{this.language}</span>}
+            </div>
+          </div>
+          <ion-button class="open-modal-btn" size="small" fill="clear" onClick={() => this.open()} ref={el => (this.itemButton = el as HTMLIonButtonElement)}>
             <ion-icon icon={eye}></ion-icon>
           </ion-button>
-        </ion-item>
+        </div>
 
         <ion-modal ref={element => (this.modal = element)} onWillDismiss={() => this.dismiss()} isOpen={false}>
           <ion-header>

--- a/packages/design-system-web/src/components/geov-entity-class-label/geov-entity-class-label.css
+++ b/packages/design-system-web/src/components/geov-entity-class-label/geov-entity-class-label.css
@@ -1,4 +1,5 @@
 :host {
   display: inline;
   vertical-align: middle;
+  color: var(--gv-class-label-color, black)
 }

--- a/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.css
+++ b/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.css
@@ -16,13 +16,16 @@ ion-item {
   border-top: solid 1px #eee;
 }
 
-a,
-a:visited {
-  color: var(--ion-text-color, #000);
+a.propertyLabel,
+a.propertyLabel:visited {
   text-decoration: none;
 }
 
-a:hover {
+a.propertyLabel:hover {
   color: var(--ion-color-primary-shade, #5e3eaa);
   text-decoration: underline;
+}
+
+.propertyLabel {
+  color: var(--gv-property-label-color, black)
 }

--- a/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.tsx
+++ b/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.tsx
@@ -212,7 +212,9 @@ export class GeovEntityPropsByPredicate {
         <ion-card color={this.color}>
           <ion-card-header>
             <ion-card-title>
-              <a href={this.predicateUri.endsWith('i') ? this.predicateUri.slice(0, -1) : this.predicateUri}>{this.predicateLabel}</a>
+              <a class="propertyLabel" href={this.predicateUri.endsWith('i') ? this.predicateUri.slice(0, -1) : this.predicateUri}>
+                {this.predicateLabel}
+              </a>
             </ion-card-title>
           </ion-card-header>
           {/* List */}

--- a/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.tsx
+++ b/packages/design-system-web/src/components/geov-entity-props-by-predicate/geov-entity-props-by-predicate.tsx
@@ -230,21 +230,11 @@ export class GeovEntityPropsByPredicate {
       return this.renderUri(item);
     }
 
-    switch (item.dt?.value) {
-      case 'http://www.opengis.net/ont/geosparql#wktLiteral':
-        return <geov-display-geosparql-wktliteral color={this.color} value={item.entity?.value}></geov-display-geosparql-wktliteral>;
-      case 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString':
-      case 'http://www.w3.org/2001/XMLSchema#string':
-      default:
-        return (
-          <geov-display-string-literal
-            color={this.color}
-            modalTitle={this.predicateLabel}
-            label={item.entity?.value}
-            language={item.entity?.['xml:lang']}
-          ></geov-display-string-literal>
-        );
-    }
+    return (
+      <ion-item>
+        <ion-label>{this.renderLiteral(item)}</ion-label>
+      </ion-item>
+    );
   }
 
   private renderUri(item: Bindings) {
@@ -298,5 +288,22 @@ export class GeovEntityPropsByPredicate {
         ></geov-paginator>
       </ion-item>
     );
+  }
+  private renderLiteral(item: Bindings) {
+    switch (item.dt?.value) {
+      case 'http://www.opengis.net/ont/geosparql#wktLiteral':
+        return <geov-display-geosparql-wktliteral color={this.color} value={item.entity?.value}></geov-display-geosparql-wktliteral>;
+      case 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString':
+      case 'http://www.w3.org/2001/XMLSchema#string':
+      default:
+        return (
+          <geov-display-string-literal
+            color={this.color}
+            modalTitle={this.predicateLabel}
+            label={item.entity?.value}
+            language={item.entity?.['xml:lang']}
+          ></geov-display-string-literal>
+        );
+    }
   }
 }

--- a/packages/design-system-web/src/components/geov-entity/geov-entity.css
+++ b/packages/design-system-web/src/components/geov-entity/geov-entity.css
@@ -52,6 +52,7 @@
 
 /* lg and up */
 @media screen and (min-width: 992px) {
+
   .columns-3,
   .columns-2 {
     --column-count: 2;

--- a/packages/design-system-web/src/components/geov-entity/geov-entity.stories.tsx
+++ b/packages/design-system-web/src/components/geov-entity/geov-entity.stories.tsx
@@ -19,6 +19,7 @@ export const ShipVoyage = await stencilWrapper(<geov-entity sparqlEndpoint={DEFA
 export const GeographicalPlace = await stencilWrapper(
   <geov-entity sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityId="i209502" language="en" fetchBeforeRender={false}></geov-entity>,
 );
+export const Presence = await stencilWrapper(<geov-entity sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityId="i253708" language="de" fetchBeforeRender={false}></geov-entity>);
 export const JohannesKepler = await stencilWrapper(<geov-entity sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityId="i785518" language="en" fetchBeforeRender={false}></geov-entity>);
 export const Birth = await stencilWrapper(<geov-entity sparqlEndpoint={AMPI_SPARQL_ENDPOINT} entityId="i542181" language="en" fetchBeforeRender={false}></geov-entity>);
 export const Group = await stencilWrapper(<geov-entity sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityId="i2215290" language="en" fetchBeforeRender={false}></geov-entity>);

--- a/packages/design-system-web/src/components/geov-entity/geov-entity.tsx
+++ b/packages/design-system-web/src/components/geov-entity/geov-entity.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 import { GeovEntityPropertiesCustomEvent } from '../../components';
 import { GeovEntityPropertiesData } from '../geov-entity-properties/geov-entity-properties';
+import { getTimeSpanUri } from '../../lib/getTimeSpanUri';
 
 /**
  * This component displays the data of a geovistory entity.
@@ -78,6 +79,11 @@ export class GeovEntity {
                   _ssrId={`${this.ssrIdPrefix}class-label`}
                   withIcon={true}
                 ></geov-entity-class-label>
+                <geov-time-span
+                  class="restricted-width"
+                  entityUri={getTimeSpanUri('http://geovistory.org/resource/' + this.entityId)}
+                  sparqlEndpoint={this.sparqlEndpoint}
+                ></geov-time-span>
               </p>
               <h1>
                 <geov-entity-label entityId={this.entityId} sparqlEndpoint={this.sparqlEndpoint} _ssrId={`${this.ssrIdPrefix}entity-label`}></geov-entity-label>
@@ -87,7 +93,6 @@ export class GeovEntity {
               </p>
             </ion-grid>
           </div>
-
           <slot name="body-start"></slot>
 
           {/* <div class="ion-padding">

--- a/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.css
+++ b/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.css
@@ -25,7 +25,7 @@
   line-height: 1.2;
 }
 
-.nestedProp ion-label p {
+.nestedProp .propLabel {
   color: var(--ion-color-primary, #000);
   text-transform: uppercase;
   font-size: 0.7rem;
@@ -43,4 +43,11 @@ a:visited {
 ion-col {
   padding: 0;
   margin: 0;
+}
+
+geov-display-string-literal {
+  --border-top: none;
+  --padding-start: 0;
+  --min-height: 0;
+  --inner-padding-end: 0;
 }

--- a/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.css
+++ b/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.css
@@ -21,7 +21,7 @@
   margin: 0px;
   padding: 0px;
   font-size: 1.1rem;
-  font-weight: 700;
+  /* font-weight: 700; */
   line-height: 1.2;
 }
 
@@ -29,6 +29,10 @@
   color: var(--ion-color-primary, #000);
   text-transform: uppercase;
   font-size: 0.7rem;
+}
+
+.classLabel {
+  color: var(--ion-color-primary, #000);
 }
 
 .nestedProp ion-label h3 {
@@ -50,4 +54,8 @@ geov-display-string-literal {
   --padding-start: 0;
   --min-height: 0;
   --inner-padding-end: 0;
+}
+
+geov-time-span {
+  display: inline;
 }

--- a/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.stories.tsx
+++ b/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.stories.tsx
@@ -1,5 +1,5 @@
 import { h } from '@stencil/core';
-import { DEFAULT_SPARQL_ENDPOINT } from '../../../.storybook/config/defaulSparqlEndpoint';
+import { AMPI_SPARQL_ENDPOINT, DEFAULT_SPARQL_ENDPOINT, MARITIME_SPARQL_ENDPOINT } from '../../../.storybook/config/defaulSparqlEndpoint';
 import { docsTemlpate } from '../../../.storybook/templates/docsTemplate';
 import { stencilWrapper } from '../../../.storybook/lib/stencilWrapper';
 import componentApi from './docs-component-api.md?raw';
@@ -15,18 +15,108 @@ export default {
   },
 };
 
-export const EntityNestedPropertiesDeath = await stencilWrapper(
-  <geov-list-item-nested-properties sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityUri="i1772506" language="en" fetchBeforeRender={false}></geov-list-item-nested-properties>,
+export const Person = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i868683'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+export const Birth = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i868690'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+export const TimeSpan = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i868690ts'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
 );
 
-export const EntityNestedPropertiesBorn = await stencilWrapper(
-  <geov-list-item-nested-properties sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityUri="i1772506" language="en" fetchBeforeRender={false}></geov-list-item-nested-properties>,
+export const DateTimeDescription = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i816636'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
 );
 
-export const EntityNestedProperties = await stencilWrapper(
-  <geov-list-item-nested-properties sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityUri="i1772506" language="en" fetchBeforeRender={false}></geov-list-item-nested-properties>,
+export const AnnotationInText = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i2486333'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
 );
 
-export const EntityNestedPropertiesTest = await stencilWrapper(
-  <geov-list-item-nested-properties sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT} entityUri="i152185" language="en" fetchBeforeRender={false}></geov-list-item-nested-properties>,
+export const Text = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i2345726'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+
+export const Definition = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i2244657'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+
+export const SourceContentCreation = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={AMPI_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i994821'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+
+export const PersonTwo = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={DEFAULT_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i1772506'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+
+export const ShipVoyage = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i153984'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+
+export const GeographicalPlace = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i209325'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
+);
+
+export const Presence = await stencilWrapper(
+  <geov-list-item-nested-properties
+    sparqlEndpoint={MARITIME_SPARQL_ENDPOINT}
+    entityUri={'http://geovistory.org/resource/i252513'}
+    language="en"
+    fetchBeforeRender={false}
+  ></geov-list-item-nested-properties>,
 );

--- a/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.tsx
+++ b/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.tsx
@@ -1,40 +1,55 @@
-import { Component, Host, Prop, State, h } from '@stencil/core';
-import { SparqlBinding, sparqlJson } from '../../lib/sparqlJson';
+import { Color } from '@ionic/core';
+import { Component, Fragment, Host, Prop, State, h } from '@stencil/core';
 import { FetchResponse } from '../../lib/FetchResponse';
-import { setSSRId } from '../../lib/ssr/setSSRId';
+import { regexReplace } from '../../lib/regexReplace';
+import { SparqlBinding, sparqlJson } from '../../lib/sparqlJson';
 import { getSSRData } from '../../lib/ssr/getSSRData';
 import { setSSRData } from '../../lib/ssr/setSSRData';
+import { setSSRId } from '../../lib/ssr/setSSRId';
 
-const qrNestedProps = (entityId: string, language: string) => {
-  return `
-  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-  PREFIX owl: <http://www.w3.org/2002/07/owl#>
-  PREFIX xml: <http://www.w3.org/XML/1998/namespace>
-  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-  PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-  PREFIX time: <http://www.w3.org/2006/time#>
-  PREFIX ontome: <https://ontome.net/ontology/>
-  PREFIX geov: <http://geovistory.org/resource/>
+const qrNestedProps = (entityUri: string, language: string) => {
+  return ` PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX owl: <http://www.w3.org/2002/07/owl#>
+    PREFIX xml: <http://www.w3.org/XML/1998/namespace>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+    PREFIX time: <http://www.w3.org/2006/time#>
+    PREFIX ontome: <https://ontome.net/ontology/>
+    PREFIX geov: <http://geovistory.org/resource/>
 
-  SELECT ?predicate ?predicateLabel ?object ?objectLabel ?predicateTimeSpan ?predicateTimeSpanLabel ?dateTimeDescriptionLabel
-  WHERE {
-      geov:${entityId} ?predicate ?object.
-      OPTIONAL{ ?object rdfs:label ?objectLabel } .
+    SELECT
+      ?predicate # predicate uri
+      ?count # count of props per predicate
+      ?object # one sample object per predicate
+      (GROUP_CONCAT(DISTINCT ?pLabel; separator=", ") as ?predicateLabel) # predicate label
+      (GROUP_CONCAT(DISTINCT ?oLabel; separator=", ") as ?objectLabel) # object label
+    WHERE {
 
-      ?predicate rdfs:label ?predicateLabel .
-      FILTER(LANG(?predicateLabel) IN ("${language}", "en")) .
+      # Innermost subquery:
+      {
+        # Select all properties of entity, group by predicate, count
+        # and select one sample object per predicate
+        SELECT ?predicate (count(?predicate) as ?count) (sample(?o) as ?object) WHERE {
+          <${entityUri}> ?predicate ?o.
+        }
+        GROUP BY ?predicate
+      }.
 
-      OPTIONAL{
-        FILTER REGEX(str(?object), "(ts)$") .
-        ?object ?predicateTimeSpan ?dateTimeDescription .
-    	  ?predicateTimeSpan rdfs:label ?predicateTimeSpanLabel .
-        ?dateTimeDescription rdfs:label ?dateTimeDescriptionLabel .
-      	FILTER(LANG(?predicateTimeSpanLabel) IN ("${language}", "en")) .
-    	  ?dateTimeDescription rdf:type time:DateTimeDescription
-      }
+      # Left join predicate labels
+      OPTIONAL {
+        ?predicate rdfs:label ?pLabel . FILTER(LANG(?pLabel) IN ("${language}", "en")) .
+      }.
+
+      # Left join add object labels
+      OPTIONAL {
+        ?object rdfs:label ?oLabel
+      }.
   }
-  LIMIT 10`;
+
+  GROUP BY ?predicate ?count ?object
+  # limit to max 50 predicate groups
+  LIMIT 50`;
 };
 
 export interface NestedProps {
@@ -42,9 +57,7 @@ export interface NestedProps {
   predicateLabel?: SparqlBinding;
   object?: SparqlBinding;
   objectLabel?: SparqlBinding;
-  predicateTimeSpan?: SparqlBinding;
-  predicateTimeSpanLabel?: SparqlBinding;
-  dateTimeDescriptionLabel?: SparqlBinding;
+  count?: SparqlBinding;
 }
 
 export interface GeovListItemNestedPropertiesData extends FetchResponse {
@@ -52,6 +65,9 @@ export interface GeovListItemNestedPropertiesData extends FetchResponse {
   error?: boolean;
 }
 
+/**
+ * This component displays information about an entity (URI) in a compact way.
+ */
 @Component({
   tag: 'geov-list-item-nested-properties',
   styleUrl: 'geov-list-item-nested-properties.css',
@@ -61,7 +77,10 @@ export class GeovListItemNestedProperties {
   /**
    * declares an _ssrId property that is reflected as attribute
    */
-  @Prop({ reflect: true }) _ssrId?: string;
+  @Prop({
+    reflect: true,
+  })
+  _ssrId?: string;
   /**
    * declares data as state
    */
@@ -102,6 +121,27 @@ export class GeovListItemNestedProperties {
    * 'http://www.w3.org/2000/01/rdf-schema#label,https://ontome.net/ontology/p86i'
    */
   @Prop() predicateExclude?: string;
+  /**
+   * uriRegex
+   * Optional regex with capturing groups to transform
+   * the uri into the desired url. To use together
+   * with uriReplace.
+   */
+  @Prop() uriRegex?: string;
+  /**
+   * uriReplace
+   * String used to replace the uriRegex.
+   *
+   * Example (pseudo code):
+   * const uriRegex = (http:\/\/geovistory.org\/)(.*)
+   * const uriReplace = "http://dev.geovistory.org/resource/$2?p=123"
+   * http://geovistory.org/resource/i54321 => http://dev.geovistory.org/resource/54321?p=123
+   */
+  @Prop() uriReplace?: string;
+  /**
+   * Color assigned to ion-item
+   */
+  @Prop() color: Color = '';
 
   /*
    * assigns an id to the component
@@ -120,13 +160,16 @@ export class GeovListItemNestedProperties {
 
     if (!this.data) {
       // set data to loading (in immutable way)
-      this.data = { loading: true };
+      this.data = {
+        loading: true,
+      };
 
       // fetch data via http
       await this.fetchData() // <- await this promise!
+
         .then(d => {
           // filter language
-          d.nestedProps = this.filterByLanguage(d.nestedProps ?? [], this.language);
+          d.nestedProps = d.nestedProps ?? []; // this.filterByLanguage(d.nestedProps ?? [], this.language);
           this.data = d;
           setSSRData(this._ssrId, d);
           return d;
@@ -138,51 +181,80 @@ export class GeovListItemNestedProperties {
     }
   }
 
-  private filterByLanguage(props: NestedProps[], lang: string) {
-    //If we have 2 differents labels in the same language, concatenate for one and deactivate for the other
-    props.map(pr => {
-      props
-        .filter(anpr => {
-          return (
-            pr.predicate.value != 'https://ontome.net/ontology/p4' &&
-            pr.predicate.value == anpr.predicate.value &&
-            pr != anpr &&
-            pr.predicateLabel['xml:lang'] == anpr.predicateLabel['xml:lang']
-          );
-        })
-        .forEach(anpr => {
-          if (pr.predicateLabel.value != anpr.predicateLabel.value) {
-            pr.predicateLabel.value += ', ' + anpr.predicateLabel.value;
-          }
-          anpr.predicateLabel['xml:lang'] = 'deactivate'; //It's just a trick
-        });
-    });
+  render() {
+    const { rdfTypeProp, rdfsLabelProp, restProps } = this.splitProps(this.data.nestedProps);
 
-    return props.filter(pr => {
-      // Find if there are other identical predicates
-      if (
-        props.filter(anpr => {
-          return pr.predicate.value == anpr.predicate.value && pr != anpr;
-        }).length
-      ) {
-        // Yes another same predicate. Priority selected language
-        if (pr.predicateLabel['xml:lang'] == lang) {
-          //We keep pr
-          return true;
-        } else {
-          //We don't keep pr
-          return false;
-        }
-      } else {
-        //No, we keep pr
-        return true;
-      }
-    });
+    return (
+      <Host>
+        <ion-item lines="none" class="itemNested">
+          <ion-label>
+            <p>
+              <a href={rdfTypeProp.object.value} target="_blank">
+                {rdfTypeProp?.objectLabel?.value}
+              </a>
+            </p>
+            <h3>
+              <a href={this.prepareUrl(this.entityUri)} target="_blank">
+                {rdfsLabelProp?.object?.value}
+              </a>
+            </h3>
+          </ion-label>
+        </ion-item>
+        <ion-grid>
+          <ion-row>
+            {restProps.map(b => (
+              <ion-col>
+                <ion-item lines="none" class="nestedProp">
+                  <ion-label>
+                    <p>
+                      {this.renderPredicateLabel(b.predicateLabel, b.predicate)}
+                      {this.renderCount(b.count)}
+                    </p>
+                    <h3> {this.renderObject(b.object, b.objectLabel, this.getPredicateLabel(b.predicateLabel, b.predicate))}</h3>
+                  </ion-label>
+                </ion-item>
+              </ion-col>
+            ))}
+          </ion-row>
+        </ion-grid>
+        <slot></slot>
+      </Host>
+    );
+  }
+
+  /**
+   * Splits the property array into three parts:
+   * - one rdfs:label prop (entity label)
+   * - one rdf:type prop (class label)
+   * - all other props
+   * @param props
+   * @returns
+   */
+  splitProps(props: NestedProps[]) {
+    let rdfsLabelProp: NestedProps;
+    let rdfTypeProp: NestedProps;
+    const restProps: NestedProps[] = [];
+
+    for (const p of props) {
+      if (p.predicate.value === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type') rdfTypeProp = p;
+      else if (p.predicate.value === 'http://www.w3.org/2000/01/rdf-schema#label') rdfsLabelProp = p;
+      else restProps.push(p);
+    }
+
+    return {
+      rdfTypeProp,
+      rdfsLabelProp,
+      restProps,
+    };
   }
 
   async fetchData(): Promise<GeovListItemNestedPropertiesData> {
-    let d: GeovListItemNestedPropertiesData = { loading: true };
-    const query = qrNestedProps(this.entityUri.split('/').at(-1), this.language);
+    let d: GeovListItemNestedPropertiesData = {
+      loading: true,
+    };
+
+    const query = qrNestedProps(this.entityUri, this.language);
+
     await sparqlJson<NestedProps>(this.sparqlEndpoint, query)
       .then(res => {
         d = {
@@ -200,70 +272,71 @@ export class GeovListItemNestedProperties {
     return d;
   }
 
-  render() {
-    const url = this.entityUri;
-
-    let label: string;
-    let type: string;
-    this.data.nestedProps
-      .filter(b => {
-        return b.predicateLabel?.value == 'has label' || b.predicateLabel?.value == 'has type';
-      })
-      .map(b => {
-        const value = b.dateTimeDescriptionLabel?.value ?? b.objectLabel?.value ?? b.object?.value ?? '';
-        if (b.predicateLabel?.value == 'has label') {
-          label = value;
-        }
-        if (b.predicateLabel?.value == 'has type') {
-          type = value;
-        }
-      });
+  /**
+   * render the predicate label
+   * @param predicateLabel
+   * @param predicate
+   * @returns jsx element
+   */
+  renderPredicateLabel(predicateLabel: SparqlBinding, predicate: SparqlBinding) {
     return (
-      <Host>
-        <ion-item href={url} lines="none" class="itemNested">
-          <ion-label>
-            <p>{type}</p>
-            <h3>{label}</h3>
-          </ion-label>
-        </ion-item>
-        <ion-grid fixed={true}>
-          <ion-row>
-            {this.data.nestedProps
-              .filter(b => {
-                return b.predicateLabel?.value != 'has label' && b.predicateLabel?.value != 'has type';
-              })
-              .map(b => (
-                <ion-col>
-                  <ion-item lines="none" class="nestedProp">
-                    <ion-label>
-                      <p>
-                        {b.predicateTimeSpanLabel
-                          ? b.predicateTimeSpanLabel.value
-                          : b.predicateLabel
-                          ? b.predicateLabel?.value
-                          : b.predicate.value.replace('http://www.w3.org/2000/01/rdf-schema#', 'rdfs:').replace('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:')}
-                      </p>
-                      <h3>
-                        {b.dateTimeDescriptionLabel ? (
-                          b.dateTimeDescriptionLabel.value
-                        ) : b.objectLabel ? (
-                          b.objectLabel?.value
-                        ) : b.object && b.object?.type == 'uri' ? (
-                          <a href={b.object?.value} target="_blank">
-                            {b.object?.value}
-                          </a>
-                        ) : (
-                          b.object?.value
-                        )}
-                      </h3>
-                    </ion-label>
-                  </ion-item>
-                </ion-col>
-              ))}
-          </ion-row>
-        </ion-grid>
-        <slot></slot>
-      </Host>
+      <a class="propLabel" href={predicate.value} target="_blank">
+        {this.getPredicateLabel(predicateLabel, predicate)}
+      </a>
     );
+  }
+  /**
+   * extract the predicate label string from predicate label and predicate bindings.
+   * It returns the predicate label, if available, else the predicate uri.
+   * in case the predicate uri is rendered, abbreviate the most common uris.
+   * @param predicateLabel
+   * @param predicate
+   * @returns string
+   */
+  getPredicateLabel(predicateLabel: SparqlBinding, predicate: SparqlBinding) {
+    return predicateLabel?.value ?? predicate.value.replace('http://www.w3.org/2000/01/rdf-schema#', 'rdfs:').replace('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:');
+  }
+  /**
+   * render the count information (only if count > 1)
+   * @param count
+   * @returns jsx element
+   */
+  renderCount(count: SparqlBinding) {
+    const c = parseInt(count?.value);
+    if (c > 1) return <Fragment>&nbsp;({count?.value})</Fragment>;
+    return;
+  }
+
+  renderObject(object: SparqlBinding, objectLabel: SparqlBinding, modalTitle: string) {
+    // if object is a URI
+    if (object?.type === 'uri') {
+      return (
+        <a href={this.prepareUrl(object?.value)} target="_blank">
+          {/* use entity label if available. Else the URI */}
+          {objectLabel?.value ?? object?.value}
+        </a>
+      );
+    }
+    console.log(modalTitle);
+    // return object?.value;
+    // else it is a literal
+    switch (object?.datatype) {
+      case 'http://www.opengis.net/ont/geosparql#wktLiteral':
+        return <geov-display-geosparql-wktliteral color={this.color} value={object?.value}></geov-display-geosparql-wktliteral>;
+      case 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString':
+      case 'http://www.w3.org/2001/XMLSchema#string':
+      default:
+        return <geov-display-string-literal color={this.color} modalTitle={modalTitle} label={object?.value} language={object?.['xml:lang']}></geov-display-string-literal>;
+    }
+  }
+
+  /**
+   * Prepares a url by applying the uirRegex and uriReplace
+   *
+   * @param url
+   * @returns string
+   */
+  prepareUrl(url: string) {
+    return regexReplace(url, this.uriRegex, this.uriReplace);
   }
 }

--- a/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.tsx
+++ b/packages/design-system-web/src/components/geov-list-item-nested-properties/geov-list-item-nested-properties.tsx
@@ -6,6 +6,7 @@ import { SparqlBinding, sparqlJson } from '../../lib/sparqlJson';
 import { getSSRData } from '../../lib/ssr/getSSRData';
 import { setSSRData } from '../../lib/ssr/setSSRData';
 import { setSSRId } from '../../lib/ssr/setSSRId';
+import { getTimeSpanUri } from '../../lib/getTimeSpanUri';
 
 const qrNestedProps = (entityUri: string, language: string) => {
   return ` PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -52,7 +53,7 @@ const qrNestedProps = (entityUri: string, language: string) => {
   LIMIT 50`;
 };
 
-export interface NestedProps {
+interface NestedProps {
   predicate: SparqlBinding;
   predicateLabel?: SparqlBinding;
   object?: SparqlBinding;
@@ -60,7 +61,7 @@ export interface NestedProps {
   count?: SparqlBinding;
 }
 
-export interface GeovListItemNestedPropertiesData extends FetchResponse {
+interface GeovListItemNestedPropertiesData extends FetchResponse {
   nestedProps?: NestedProps[];
   error?: boolean;
 }
@@ -77,10 +78,7 @@ export class GeovListItemNestedProperties {
   /**
    * declares an _ssrId property that is reflected as attribute
    */
-  @Prop({
-    reflect: true,
-  })
-  _ssrId?: string;
+  @Prop({ reflect: true }) _ssrId?: string;
   /**
    * declares data as state
    */
@@ -189,9 +187,10 @@ export class GeovListItemNestedProperties {
         <ion-item lines="none" class="itemNested">
           <ion-label>
             <p>
-              <a href={rdfTypeProp.object.value} target="_blank">
+              <a href={rdfTypeProp.object.value} target="_blank" class="classLabel">
                 {rdfTypeProp?.objectLabel?.value}
-              </a>
+              </a>{' '}
+              <geov-time-span sparqlEndpoint={this.sparqlEndpoint} entityUri={getTimeSpanUri(this.entityUri)}></geov-time-span>
             </p>
             <h3>
               <a href={this.prepareUrl(this.entityUri)} target="_blank">
@@ -317,7 +316,6 @@ export class GeovListItemNestedProperties {
         </a>
       );
     }
-    console.log(modalTitle);
     // return object?.value;
     // else it is a literal
     switch (object?.datatype) {

--- a/packages/design-system-web/src/components/geov-time-span/geov-time-span.css
+++ b/packages/design-system-web/src/components/geov-time-span/geov-time-span.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/packages/design-system-web/src/components/geov-time-span/geov-time-span.stories.tsx
+++ b/packages/design-system-web/src/components/geov-time-span/geov-time-span.stories.tsx
@@ -1,0 +1,20 @@
+import { h } from '@stencil/core';
+import { MARITIME_SPARQL_ENDPOINT } from '../../../.storybook/config/defaulSparqlEndpoint';
+import { stencilWrapper } from '../../../.storybook/lib/stencilWrapper';
+import { docsTemlpate } from '../../../.storybook/templates/docsTemplate';
+import componentApi from './docs-component-api.md?raw';
+import overview from './docs-overview.md?raw';
+export default {
+  title: 'Data Components/Entity/Time Span',
+  tags: ['autodocs'],
+  parameters: {
+    viewMode: 'docs',
+    docs: {
+      page: () => docsTemlpate(overview, componentApi),
+    },
+  },
+};
+
+export const ShipVoyage = await stencilWrapper(
+  <geov-time-span sparqlEndpoint={MARITIME_SPARQL_ENDPOINT} entityUri={'http://geovistory.org/resource/i153984ts'} fetchBeforeRender={false}></geov-time-span>,
+);

--- a/packages/design-system-web/src/components/geov-time-span/geov-time-span.tsx
+++ b/packages/design-system-web/src/components/geov-time-span/geov-time-span.tsx
@@ -1,0 +1,240 @@
+import { Component, Fragment, Prop, State, h } from '@stencil/core';
+import { FetchResponse } from '../../lib/FetchResponse';
+import { SparqlBinding, sparqlJson } from '../../lib/sparqlJson';
+import { getSSRData } from '../../lib/ssr/getSSRData';
+import { setSSRData } from '../../lib/ssr/setSSRData';
+import { setSSRId } from '../../lib/ssr/setSSRId';
+const qr = (entityUri: string) => `
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX owl: <http://www.w3.org/2002/07/owl#>
+    PREFIX xml: <http://www.w3.org/XML/1998/namespace>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+    PREFIX time: <http://www.w3.org/2006/time#>
+    PREFIX ontome: <https://ontome.net/ontology/>
+    PREFIX geov: <http://geovistory.org/resource/>
+
+    SELECT
+      ?predicate # predicate uri
+      (SAMPLE(?y) as ?year)
+      (SAMPLE(?m) as ?month)
+      (SAMPLE(?d) as ?day)
+      (SAMPLE(?tUnit) as ?timeUnit)
+
+    WHERE {
+
+      # Innermost subquery:
+      {
+        # Select all properties of entity, group by predicate
+        # and select one sample object per predicate
+        SELECT ?predicate (sample(?o) as ?object) WHERE {
+          <${entityUri}> ?predicate ?o.
+        }
+        GROUP BY ?predicate
+      }.
+
+  	  # Left year, month, day
+      OPTIONAL { ?object time:year ?y }.
+      OPTIONAL { ?object time:month ?m }.
+      OPTIONAL { ?object time:day ?d }.
+      OPTIONAL { ?object time:unitType ?tUnit }.
+  }
+
+  GROUP BY ?predicate ?object
+  # limit to max 50 predicate groups
+  LIMIT 50`;
+
+interface Row {
+  predicate: SparqlBinding;
+  year?: SparqlBinding;
+  month?: SparqlBinding;
+  day?: SparqlBinding;
+  timeUnit?: SparqlBinding;
+}
+interface Data extends FetchResponse {
+  rows?: Row[];
+  error?: boolean;
+}
+interface TimeInfo {
+  year?: number;
+  month?: number;
+  day?: number;
+  timeUnit: string;
+}
+
+/**
+ * This component queries and renders the dates of a time span as readable string
+ *
+ * - In case there are mutiple dates, the output is {earliest} – {latest}: `1739-11-25 – 1740-07-08`
+ * - In case there is one date, the output is {date}: `1739-11-25`
+ * - In case there is no date, the output is empty
+ *
+ * Remark: The predicates from Time Span to Date, like `crm:P81b begin of the end`, are not taken into account for
+ * the retrieval of {earliest} and {latest}.
+ *
+ * @param rows
+ */
+@Component({
+  tag: 'geov-time-span',
+  styleUrl: 'geov-time-span.css',
+  shadow: true,
+})
+export class GeovTimeSpan {
+  /**
+   * declares an _ssrId property that is reflected as attribute
+   */
+  @Prop({ reflect: true }) _ssrId?: string;
+  /**
+   * declares data as state
+   */
+  @State() data?: Data;
+  /**
+   * if true, componentWillLoad() returns a promise for the loading of all data [default: true]
+   */
+  @Prop() fetchBeforeRender = true;
+  /**
+   * sparqlEndpoint
+   * URL of the sparql endpoint
+   */
+  @Prop() sparqlEndpoint: string;
+  /**
+   * entityId
+   * Uri of subject, e.g. 'http://www.geovistory.org/ressource/iXXX'
+   */
+  @Prop() entityUri: string;
+
+  /*
+   * assigns an id to the component
+   */
+  constructor() {
+    setSSRId(this);
+  }
+
+  async componentWillLoad() {
+    if (this.fetchBeforeRender) {
+      /**
+       * try to get data from ssr
+       */
+      this.data = getSSRData(this._ssrId);
+    }
+
+    if (!this.data) {
+      // set data to loading (in immutable way)
+      this.data = {
+        loading: true,
+      };
+
+      // fetch data via http
+      await this.fetchData() // <- await this promise!
+
+        .then(d => {
+          // filter language
+          this.data = d;
+          setSSRData(this._ssrId, d);
+          return d;
+        })
+        .catch(d => {
+          this.data = d;
+          return d;
+        });
+    }
+  }
+  async fetchData(): Promise<Data> {
+    let d: Data = {
+      loading: true,
+    };
+
+    const query = qr(this.entityUri);
+    await sparqlJson<Row>(this.sparqlEndpoint, query)
+      .then(res => {
+        d = {
+          loading: false,
+          rows: res?.results?.bindings,
+        };
+      })
+      .catch(_ => {
+        d = {
+          loading: false,
+          error: true,
+        };
+      });
+
+    return d;
+  }
+  /**
+   * Converts the rows into a readable string
+   *
+   * In case there are mutiple dates, the output is {earliest} – {latest}:
+   * 1739-11-25 – 1740-07-08
+   *
+   * In case there is one date, the output is {date}:
+   * 1739-11-25
+   *
+   * In case there is no date, the output is empty
+   *
+   * @param rows
+   */
+  rowsToString(rows: Row[]) {
+    const timeInfos = rows
+      // map rows to year month time
+      .map(r => this.getTime(r))
+      // filter items with time info
+      .filter(timeInfo => !!timeInfo.timeUnit)
+      // sort earliest date first
+      .sort((a, b) => {
+        // Compare years
+        if (a.year !== b.year) {
+          return a.year - b.year;
+        }
+
+        // Compare months
+        if (a.month !== b.month) {
+          return a.month - b.month;
+        }
+
+        // Compare days
+        return a.day - b.day;
+      });
+
+    // return if we have no time info
+    if (timeInfos.length === 0) return;
+
+    const earliest = timeInfos[0];
+    const latest = timeInfos[timeInfos.length - 1];
+
+    if (earliest === latest) return this.timeInfoToString(earliest);
+
+    return `${this.timeInfoToString(earliest)} – ${this.timeInfoToString(latest)}`;
+  }
+  /**
+   * Extracts TimeInfo from a Row
+   */
+  getTime(row: Row): TimeInfo {
+    return {
+      year: parseInt(row.year?.value),
+      month: parseInt(row.month?.value?.replace('--', '')),
+      day: parseInt(row.day?.value?.replace('---', '')),
+      timeUnit: row.timeUnit?.value,
+    };
+  }
+  /**
+   * Converts a timeInfo to a string
+   * @param timeInfo
+   * @returns
+   */
+  timeInfoToString(timeInfo: TimeInfo) {
+    switch (timeInfo.timeUnit) {
+      case 'http://www.w3.org/2006/time#unitYear':
+        return `${timeInfo.year}`;
+      case 'http://www.w3.org/2006/time#unitMonth':
+        return `${timeInfo.year}.${timeInfo.month.toString().padStart(2, '0')}`;
+      case 'http://www.w3.org/2006/time#unitDay':
+      default:
+        return `${timeInfo.year}.${timeInfo.month.toString().padStart(2, '0')}.${timeInfo.day.toString().padStart(2, '0')}`;
+    }
+  }
+  render() {
+    return <Fragment>{this.rowsToString(this.data.rows)}</Fragment>;
+  }
+}

--- a/packages/design-system-web/src/global/global.scss
+++ b/packages/design-system-web/src/global/global.scss
@@ -159,6 +159,11 @@
   --swiper-theme-color: var(--ion-color-primary);
 
   --gv-color-background-code: #f5f2f0;
+
+  /* color of OWL property labels*/
+  --gv-property-label-color: var(--ion-color-primary);
+  /* color of OWL class labels*/
+  --gv-class-label-color: var(--ion-color-primary);
 }
 
 geov-code {

--- a/packages/design-system-web/src/lib/getTimeSpanUri.tsx
+++ b/packages/design-system-web/src/lib/getTimeSpanUri.tsx
@@ -1,0 +1,18 @@
+/**
+ * Converts a entity URI to the URI of its Time Span.
+ *
+ * If the uri ends on 'ts', we assume, it already is a timespan uri and return it.
+ * Else we assume it is a normal geovistory uri and append 'ts' and return it.
+ *
+ * e.g:
+ * http://.geovistory.org/resource/i868690 -> http://.geovistory.org/resource/i868690ts
+ * http://.geovistory.org/resource/i868690ts -> http://.geovistory.org/resource/i868690ts
+ *
+ * @param uri g
+ * @returns
+ */
+
+export function getTimeSpanUri(uri: string) {
+  if (uri.endsWith('ts')) return uri;
+  return uri + 'ts';
+}


### PR DESCRIPTION
This PR aims to add some features and improvements:

In `geov-list-item-nested-properties` 
- Group by predicate and count in the sparql query (instead of filtering in JavaScript)
- Display a count for each property
- Add links to properties and classes  
- Add links to entities
- Wrap literals in existing components for literals
- Exclude time span query to separate component `geov-time-span`

Add `geov-time-span`
- Component to query time span props and create a readable string

In `geov-entity`
- Add `geov-time-span`
